### PR TITLE
Add: CachedAsyncImage 추가

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,13 +10,17 @@ let package = Package(
   products: [
     .library(
       name: "CachedImageLoader",
-      targets: ["CachedImageLoader"]),
+      targets: ["CachedImageLoader", "CachedAsyncImage"]),
   ],
   dependencies: [],
   targets: [
     .target(
       name: "CachedImageLoader",
       dependencies: []
+    ),
+    .target(
+      name: "CachedAsyncImage",
+      dependencies: ["CachedImageLoader"]
     ),
   ]
 )

--- a/Sources/CachedAsyncImage/CachedAsyncImage.swift
+++ b/Sources/CachedAsyncImage/CachedAsyncImage.swift
@@ -8,87 +8,95 @@
 import SwiftUI
 import CachedImageLoader
 
-@available(iOS 15, *)
 public struct CachedAsyncImage<Content: View>: View {
-    private let url: URL?
-    private let imageLoader: CachedImageLoader
-    private let scale: CGFloat
-    private let transaction: Transaction
-    private let content: (AsyncImagePhase) -> Content
-    @State private var phase: AsyncImagePhase
-    
-    public init(
-        url: URL?,
-        imageLoader: CachedImageLoader = .shared,
-        scale: CGFloat = 1
-    ) where Content == Image {
-        self.init(
-            url: url,
-            imageLoader: imageLoader,
-            scale: scale
-        ) { phase in
-            phase.image ?? Image(uiImage: .init())
+  private let url: URL?
+  private let imageLoader: CachedImageLoader
+  private let scale: CGFloat
+  private let transaction: Transaction
+  private let content: (CachedAsyncImagePhase) -> Content
+  @State private var phase: CachedAsyncImagePhase
+  
+  public init(
+    url: URL?,
+    imageLoader: CachedImageLoader = .shared,
+    scale: CGFloat = 1
+  ) where Content == Image {
+    self.init(
+      url: url,
+      imageLoader: imageLoader,
+      scale: scale
+    ) { phase in
+      phase.image ?? Image(uiImage: .init())
+    }
+  }
+  
+  public init<I: View, P: View>(
+    url: URL?,
+    imageLoader: CachedImageLoader = .shared,
+    scale: CGFloat = 1,
+    @ViewBuilder content: @escaping (Image) -> I,
+    @ViewBuilder placeholder: @escaping () -> P
+  ) where Content == _ConditionalContent<I, P> {
+    self.init(
+      url: url,
+      imageLoader: imageLoader,
+      scale: scale
+    ) { phase in
+      if let image = phase.image {
+        content(image)
+      } else {
+        placeholder()
+      }
+    }
+  }
+  
+  public init(
+    url: URL?,
+    imageLoader: CachedImageLoader = .shared,
+    scale: CGFloat = 1,
+    transaction: Transaction = .init(),
+    @ViewBuilder content: @escaping (CachedAsyncImagePhase) -> Content
+  ) {
+    self.imageLoader = imageLoader
+    self.url = url
+    self.scale = scale
+    self.transaction = transaction
+    self.content = content
+    self._phase = State(wrappedValue: .empty)
+  }
+  
+  private func load() async {
+    do {
+      if let data = try await imageLoader.load(url),
+         let uiImage = UIImage(data: data, scale: scale) {
+        withAnimation(transaction.animation) {
+          phase = .success(Image(uiImage: uiImage))
+        }
+      } else {
+        withAnimation(transaction.animation) {
+          phase = .empty
+        }
+      }
+    } catch {
+      withAnimation(transaction.animation) {
+        phase = .failure(error)
+      }
+    }
+  }
+  
+  public var body: some View {
+    if #available(iOS 15.0, *) {
+      content(phase)
+        .task {
+          await load()
+        }
+    } else {
+      content(phase)
+        .onAppear {
+          Task {
+            await load()
+          }
         }
     }
-    
-    public init<I: View, P: View>(
-        url: URL?,
-        imageLoader: CachedImageLoader = .shared,
-        scale: CGFloat = 1,
-        @ViewBuilder content: @escaping (Image) -> I,
-        @ViewBuilder placeholder: @escaping () -> P
-    ) where Content == _ConditionalContent<I, P> {
-        self.init(
-            url: url,
-            imageLoader: imageLoader,
-            scale: scale
-        ) { phase in
-            if let image = phase.image {
-                content(image)
-            } else {
-                placeholder()
-            }
-        }
-    }
-    
-    public init(
-        url: URL?,
-        imageLoader: CachedImageLoader = .shared,
-        scale: CGFloat = 1,
-        transaction: Transaction = .init(),
-        @ViewBuilder content: @escaping (AsyncImagePhase) -> Content
-    ) {
-        self.imageLoader = imageLoader
-        self.url = url
-        self.scale = scale
-        self.transaction = transaction
-        self.content = content
-        self._phase = State(wrappedValue: .empty)
-    }
-    
-    private func load() async {
-        do {
-            if let data = try await imageLoader.load(url) {
-                withAnimation(transaction.animation) {
-                    let uiImage = UIImage(data: data, scale: scale)!
-                    phase = .success(Image(uiImage: uiImage))
-                }
-            } else {
-                withAnimation(transaction.animation) {
-                    phase = .empty
-                }
-            }
-        } catch {
-            withAnimation(transaction.animation) {
-                phase = .failure(error)
-            }
-        }
-    }
-    
-    public var body: some View {
-        content(phase)
-            .task {
-                await load()
-            }
-    }
+  }
 }

--- a/Sources/CachedAsyncImage/CachedAsyncImage.swift
+++ b/Sources/CachedAsyncImage/CachedAsyncImage.swift
@@ -1,0 +1,94 @@
+//
+//  CachedAsyncImage.swift
+//  CachedImageLoader
+//
+//  Created by Mercen on 10/16/24.
+//
+
+import SwiftUI
+import CachedImageLoader
+
+@available(iOS 15, *)
+public struct CachedAsyncImage<Content: View>: View {
+    private let url: URL?
+    private let imageLoader: CachedImageLoader
+    private let scale: CGFloat
+    private let transaction: Transaction
+    private let content: (AsyncImagePhase) -> Content
+    @State private var phase: AsyncImagePhase
+    
+    public init(
+        url: URL?,
+        imageLoader: CachedImageLoader = .shared,
+        scale: CGFloat = 1
+    ) where Content == Image {
+        self.init(
+            url: url,
+            imageLoader: imageLoader,
+            scale: scale
+        ) { phase in
+            phase.image ?? Image(uiImage: .init())
+        }
+    }
+    
+    public init<I: View, P: View>(
+        url: URL?,
+        imageLoader: CachedImageLoader = .shared,
+        scale: CGFloat = 1,
+        @ViewBuilder content: @escaping (Image) -> I,
+        @ViewBuilder placeholder: @escaping () -> P
+    ) where Content == _ConditionalContent<I, P> {
+        self.init(
+            url: url,
+            imageLoader: imageLoader,
+            scale: scale
+        ) { phase in
+            if let image = phase.image {
+                content(image)
+            } else {
+                placeholder()
+            }
+        }
+    }
+    
+    public init(
+        url: URL?,
+        imageLoader: CachedImageLoader = .shared,
+        scale: CGFloat = 1,
+        transaction: Transaction = .init(),
+        @ViewBuilder content: @escaping (AsyncImagePhase) -> Content
+    ) {
+        self.imageLoader = imageLoader
+        self.url = url
+        self.scale = scale
+        self.transaction = transaction
+        self.content = content
+        self._phase = State(wrappedValue: .empty)
+    }
+    
+    private func load() async {
+        do {
+            if let data = try await imageLoader.load(url) {
+                withAnimation(transaction.animation) {
+                    let uiImage = UIImage(data: data, scale: scale)!
+                    phase = .success(Image(uiImage: uiImage))
+                }
+            } else {
+                withAnimation(transaction.animation) {
+                    phase = .empty
+                }
+            }
+        } catch {
+            withAnimation(transaction.animation) {
+                phase = .failure(error)
+            }
+        }
+    }
+    
+    public var body: some View {
+        content(phase)
+            .task {
+                await load()
+            }
+    }
+}

--- a/Sources/CachedAsyncImage/CachedAsyncImagePhase.swift
+++ b/Sources/CachedAsyncImage/CachedAsyncImagePhase.swift
@@ -1,0 +1,19 @@
+//
+//  CachedAsyncImagePhase.swift
+//  CachedImageLoader
+//
+//  Created by Mercen on 10/20/24.
+//
+
+import SwiftUI
+
+public enum CachedAsyncImagePhase {
+  case empty
+  case success(Image)
+  case failure(any Error)
+  
+  public var image: Image? {
+    guard case let .success(image) = self else { return nil }
+    return image
+  }
+}


### PR DESCRIPTION
SwiftUI에서 CachedImageLoader를 더 편리하게 제공하는 `CachedAsyncImage`를 새로운 target으로 추가하였습니다.

사용 방법은 SwiftUI의 [AsyncImage](https://developer.apple.com/documentation/swiftui/asyncimage)와 동일하고, 파라미터로 `imageLoader`가 추가되었습니다. 

아래는 샘플 코드입니다.

```swift
import CachedAsyncImage

struct SampleView: View {
    let url: URL
    var body: some View {
        CachedAsyncImage(url: url, imageLoader: .shared) { image in
            image
                .resizable()
                .scaledToFit()
                .frame(width: 100)
        } placeholder: {
            ProgressView()
        }
    }
}
```